### PR TITLE
Appropriately Namespaced ENV Vars

### DIFF
--- a/.github/workflows/email-job.yml
+++ b/.github/workflows/email-job.yml
@@ -31,6 +31,7 @@ jobs:
         MAILGUN__BASE_URL: ${{ secrets.MAILGUN_BASE_URL }}
         MAILGUN__SANDBOX_DOMAIN: ${{ secrets.MAILGUN_SANDBOX_DOMAIN }}
         MAILGUN__DESTINATION_EMAIL: ${{ secrets.MAILGUN_DESTINATION_EMAIL }}
+        MAILGUN__SENDING_KEY: ${{ secrets.MAILGUN_SENDING_KEY }}
       run: |
         echo "Running email pipeline..."
         python -m pipelines.email_pipeline

--- a/.github/workflows/email-job.yml
+++ b/.github/workflows/email-job.yml
@@ -26,8 +26,11 @@ jobs:
         
     - name: Run email pipeline
       env:
-        MOTHERDUCK_CREDENTIALS: ${{ secrets.MOTHERDUCK_CREDENTIALS }}
-        MAILGUN_API_KEY: ${{ secrets.MAILGUN_API_KEY }}
+        DESTINATION__MOTHERDUCK__CREDENTIALS: ${{ secrets.MOTHERDUCK_CREDENTIALS }}
+        MAILGUN__API_KEY: ${{ secrets.MAILGUN_API_KEY }}
+        MAILGUN__BASE_URL: ${{ secrets.MAILGUN_BASE_URL }}
+        MAILGUN__SANDBOX_DOMAIN: ${{ secrets.MAILGUN_SANDBOX_DOMAIN }}
+        MAILGUN__DESTINATION_EMAIL: ${{ secrets.MAILGUN_DESTINATION_EMAIL }}
       run: |
         echo "Running email pipeline..."
         python -m pipelines.email_pipeline

--- a/.github/workflows/ingest-jobs.yml
+++ b/.github/workflows/ingest-jobs.yml
@@ -26,7 +26,7 @@ jobs:
         
     - name: Run remote jobs pipeline
       env:
-        OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+        OPENAI__API_KEY: ${{ secrets.OPENAI_API_KEY }}
         DESTINATION__MOTHERDUCK__CREDENTIALS: ${{ secrets.MOTHERDUCK_CREDENTIALS }}
         RSS__REMOTE_FEED_URL: ${{ secrets.REMOTE_FEED_URL }}
         OPENAI__VECTOR_STORE_ID: ${{ secrets.OPENAI_VECTOR_STORE_ID }}
@@ -36,9 +36,9 @@ jobs:
         
     - name: Run atlanta jobs pipeline  
       env:
-        OPENAI__OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+        OPENAI__API_KEY: ${{ secrets.OPENAI_API_KEY }}
         DESTINATION__MOTHERDUCK__CREDENTIALS: ${{ secrets.MOTHERDUCK_CREDENTIALS }}
-        RSS_ATLANTA_FEED_URL: ${{ secrets.ATLANTA_FEED_URL }}
+        RSS__ATLANTA_FEED_URL: ${{ secrets.ATLANTA_FEED_URL }}
         OPENAI__VECTOR_STORE_ID: ${{ secrets.OPENAI_VECTOR_STORE_ID }}
       run: |
         echo "Running atlanta jobs pipeline..."

--- a/.github/workflows/ingest-jobs.yml
+++ b/.github/workflows/ingest-jobs.yml
@@ -27,8 +27,8 @@ jobs:
     - name: Run remote jobs pipeline
       env:
         OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
-        MOTHERDUCK_CREDENTIALS: ${{ secrets.MOTHERDUCK_CREDENTIALS }}
-        REMOTE_FEED_URL: ${{ secrets.REMOTE_FEED_URL }}
+        DESTINATION__MOTHERDUCK__CREDENTIALS: ${{ secrets.MOTHERDUCK_CREDENTIALS }}
+        RSS__REMOTE_FEED_URL: ${{ secrets.REMOTE_FEED_URL }}
         OPENAI__VECTOR_STORE_ID: ${{ secrets.OPENAI_VECTOR_STORE_ID }}
       run: |
         echo "Running remote jobs pipeline..."
@@ -36,9 +36,9 @@ jobs:
         
     - name: Run atlanta jobs pipeline  
       env:
-        OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
-        MOTHERDUCK_CREDENTIALS: ${{ secrets.MOTHERDUCK_CREDENTIALS }}
-        ATLANTA_FEED_URL: ${{ secrets.ATLANTA_FEED_URL }}
+        OPENAI__OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+        DESTINATION__MOTHERDUCK__CREDENTIALS: ${{ secrets.MOTHERDUCK_CREDENTIALS }}
+        RSS_ATLANTA_FEED_URL: ${{ secrets.ATLANTA_FEED_URL }}
         OPENAI__VECTOR_STORE_ID: ${{ secrets.OPENAI_VECTOR_STORE_ID }}
       run: |
         echo "Running atlanta jobs pipeline..."


### PR DESCRIPTION
DLT likes to use double underscores for matching against its secrets.toml file - updated the env vars in our workflows to match